### PR TITLE
don't ignore Sysex, Time and Sense messages with RtMidiAccess

### DIFF
--- a/ktmidi-jvm-desktop/src/main/kotlin/dev/atsushieno/ktmidi/RtMidiAccess.kt
+++ b/ktmidi-jvm-desktop/src/main/kotlin/dev/atsushieno/ktmidi/RtMidiAccess.kt
@@ -105,6 +105,12 @@ class RtMidiAccess() : MidiAccess() {
             library.rtmidi_in_set_callback(rtmidi,
                 callback,
                 Pointer.NULL)
+            library.rtmidi_in_ignore_types(
+                rtmidi,
+                0,
+                0,
+                0,
+            )
         }
     }
 

--- a/ktmidi-jvm-desktop/src/main/kotlin/dev/atsushieno/ktmidi/RtMidiAccess.kt
+++ b/ktmidi-jvm-desktop/src/main/kotlin/dev/atsushieno/ktmidi/RtMidiAccess.kt
@@ -108,8 +108,8 @@ class RtMidiAccess() : MidiAccess() {
             library.rtmidi_in_ignore_types(
                 rtmidi,
                 0,
-                0,
-                0,
+                1,
+                1,
             )
         }
     }


### PR DESCRIPTION
sysex, time and sense messages are ignored by RtMidi by default
this PR will allow to receive them