### PR TITLE
Fix delta calculations in Midi1TrackMerger

### DIFF
--- a/ktmidi/src/commonMain/kotlin/dev/atsushieno/ktmidi/Midi1Music.kt
+++ b/ktmidi/src/commonMain/kotlin/dev/atsushieno/ktmidi/Midi1Music.kt
@@ -298,12 +298,9 @@ internal class Midi1TrackMerger(private var source: Midi1Music) {
         var waitToNext = l[0].deltaTime
         i = 0
         while (i < l.size - 1) {
-            val m = l[i].message
-            if (m is Midi1SimpleMessage && m.value != 0) { // if non-dummy
-                val tmp = l[i + 1].deltaTime - l[i].deltaTime
-                l[i] = Midi1Event(waitToNext, l[i].message)
-                waitToNext = tmp
-            }
+            val tmp = l[i + 1].deltaTime - l[i].deltaTime
+            l[i] = Midi1Event(waitToNext, l[i].message)
+            waitToNext = tmp
             i++
         }
         l[l.size - 1] = Midi1Event(waitToNext, l[l.size - 1].message)


### PR DESCRIPTION
Currently `deltaTime` of all `Midi1CompoundMessage` and the dummy `Midi1SimpleMessage` won't be updated. All other messages after the message will be affected by the wrong `deltaTime`. Therefore, I filter all dummy messages out when rebuilding the list and remain other valid `Midi1SimpleMessage` and `Midi1CompoundMessage`.