### PR TITLE
Fix errors in sending system real-time messages in JVM

### DIFF
--- a/ktmidi/src/jvmMain/kotlin/dev/atsushieno/ktmidi/JvmMidiAccess.kt
+++ b/ktmidi/src/jvmMain/kotlin/dev/atsushieno/ktmidi/JvmMidiAccess.kt
@@ -75,7 +75,11 @@ private fun toJvmMidiMessage(data: ByteArray, start: Int, length: Int): JvmMidiM
     return when (arr[0]) {
         0xF0.toByte() -> SysexMessage(arr, length)
         0xFF.toByte() -> MetaMessage(arr[1].toInt(), arr.drop(2).toByteArray(), length - 2)
-        else -> ShortMessage(arr[0].toInt(), arr[1].toInt(), if (length > 2) arr[2].toInt() else 0)
+        else -> ShortMessage(
+            arr[0].toUByte().toInt(),
+            arr.getOrElse(1) { _ -> 0 }.toInt(),
+            arr.getOrElse(2) { _ -> 0 }.toInt()
+        )
     }
 }
 


### PR DESCRIPTION
System real-time messages such as TIMING_CLOCK(0xF8) and START(0xFA), consist of only one byte. Therefore, It also needs check the array length when filling in `data1` field of `ShortMessage`.

Additionally, JVM `ShortMessage` requires the status byte to be represented as a positive `Int`. Therefore, convert the status byte to a `UByte` first and then to `Int`. The other two bytes should not exceed 0x7F, so it's unneccesary to convert them to `UByte` first.